### PR TITLE
fix: disallow web crawler to access `/mirrors`

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,7 @@
 # robots.txt for https://mirrors.njupt.edu.cn
 User-agent: *
 
+Disallow: /mirrors
 Disallow: /AOSP
 Disallow: /CRAN
 Disallow: /CTAN


### PR DESCRIPTION
A majority of the traffic is made by web crawlers of a particular search engine through paths of perfix `/mirrors`.